### PR TITLE
Fix broken links

### DIFF
--- a/rif/index.md
+++ b/rif/index.md
@@ -24,25 +24,13 @@ RIF OS Protocols enable broad interoperability and faster time-to-deployment, an
 
 RNS is a decentralized service that allows users to have a readable domain or alias. It can be used to identify other personal resources, such as payment or communication addresses.
 
-Learn more about [RIF Name Service](./rns)
-
-#### RIF Lumino Network
-
-RIF Lumino Network is a third-layer solution to the Bitcoin blockchain, that enables state channels for every token built on Rootstock (RSK) increasing transaction throughput and reduces costs by orders of magnitude.
-
-Learn more about [RIF Lumino Network](./lumino)
-
-### RIF Marketplace
-
-RIF Marketplace provides a one-stop shop for a wide variety of decentralized services, presenting a unified/simplified interface and user experience. 
-
-Learn more about [RIF Marketplace](./marketplace)
+Learn more about [RIF Name Service](../rif/rns/)
 
 ### RIF Gateways
 
 RIF Gateways develops tools and technologies to allow decentralized applications to seamlessly connect to the external world. 
 
-Learn more about [RIF Gateways](./gateways)
+Learn more about [RIF Gateways](../rif/gateways/)
 
 #### RIF OS White Paper
 

--- a/rif/rlogin/index.md
+++ b/rif/rlogin/index.md
@@ -157,7 +157,7 @@ Follow this guide to configure rLogin in minutes
   <div class="row rif_blue_text">
     <div class="col">
       <div class="rns-index-box">
-        <a href="../features">Features</a>
+        <a href="../rlogin/features">Features</a>
         <br />
         <br />
         <p>i18n, theming, dark/light, listeners, triggers</p>
@@ -165,7 +165,7 @@ Follow this guide to configure rLogin in minutes
     </div>
     <div class="col">
       <div class="rns-index-box">
-        <a href="../samples">rLogin sample apps</a>
+        <a href="../rlogin/samples/">rLogin sample apps</a>
         <br />
         <br />
         <p>Sample apps! Find all the code you need</p>
@@ -175,7 +175,7 @@ Follow this guide to configure rLogin in minutes
   <div class="row rif_blue_text">
     <div class="col">
       <div class="rns-index-box">
-        <a href="../authentication">Integrated backend authentication</a>
+        <a href="../rlogin/authentication">Integrated backend authentication</a>
         <br />
         <br />
         <p>Integrate the authentication model based on the user's digital signature capabilities</p>
@@ -183,7 +183,7 @@ Follow this guide to configure rLogin in minutes
     </div>
     <div class="col">
       <div class="rns-index-box">
-        <a href="../migrating">Migrating</a>
+        <a href="../rlogin/migrating/">Migrating</a>
         <br />
         <br />
         <p>From <code>web3modal</code> or <code>web3react</code></p>
@@ -245,6 +245,6 @@ rLogin supports Metamask features to change the network from the app. For the ot
 
 ![rlogin-architecture-simple](/rif/rlogin/assets/rlogin-architecture-simple.png)
 
-Read more about the architecture [here](../design-and-architecture)
+Read more about the architecture [here](https://dev.rootstock.io/rif/rlogin/design-and-architecture/)
 
-> Follow the [development guidelines](../develop) to collaborate
+> Follow the [development guidelines](https://dev.rootstock.io/rif/rlogin/develop/) to collaborate

--- a/rif/rlogin/index.md
+++ b/rif/rlogin/index.md
@@ -245,6 +245,6 @@ rLogin supports Metamask features to change the network from the app. For the ot
 
 ![rlogin-architecture-simple](/rif/rlogin/assets/rlogin-architecture-simple.png)
 
-Read more about the architecture [here](https://dev.rootstock.io/rif/rlogin/design-and-architecture/)
+Read more about the architecture [here](../rlogin/design-and-architecture.md)
 
-> Follow the [development guidelines](https://dev.rootstock.io/rif/rlogin/develop/) to collaborate
+> Follow the [development guidelines](../rlogin/develop.md) to collaborate


### PR DESCRIPTION
## What

fixed broken links and removed RIF Lumino and RIF Marketplace sections

## Why

- links broke through previous update and RIF Lumino & Marketplace are no longer available. 

## Refs

- none
