### PR TITLE
removed menu_order in wallets index

### DIFF
--- a/wallet/index.md
+++ b/wallet/index.md
@@ -2,9 +2,6 @@
 layout: rsk
 title: Wallets
 tags: rif, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
-menu_order: 12
-menu_title: Wallets
-section_title: Wallets
 ---
 
 ## Use a wallet


### PR DESCRIPTION
## What

- Wallets still appear on left nav as a standalone, removed menu_order to fix this

## Why

- Related to #44 

## Refs

- (optional: include links to other issues, PRs, tickets, etc)
